### PR TITLE
Append prompt and command to history 

### DIFF
--- a/src/lib/chatter.rs
+++ b/src/lib/chatter.rs
@@ -83,7 +83,7 @@ impl Chatter {
                 match answer {
                     "✅ Execute" => {
                         debug!("{} {:?}", SHELL.cmd, &[&SHELL.arg, &command]);
-                        let code = SHELL.run_command(&command)?;
+                        let code = SHELL.run_command(&command, text)?;
                         if code != 0 {
                             process::exit(code);
                         }


### PR DESCRIPTION
Most of the work to append to the history of `bash` and `zsh` was already done. The only thing missing was to make shells interactive (hence the `-i` argument), in order to have history available and to also activate the history by running `set -o history`. 

Additionally this PR adds the user prompt as a comment after the command to the history.  This way it's easier for the user to find the command generated by a prompt later again.